### PR TITLE
Style options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "asciic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "ctrlc",
@@ -27,7 +27,7 @@ version = "0.1.0"
 
 [[package]]
 name = "asciix"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "tar",
@@ -105,11 +105,26 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -309,6 +324,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -548,6 +569,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +761,12 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/asciic/Cargo.toml
+++ b/asciic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.2.22"
+clap = { version = "3.2.22", features = ["derive"] }
 ctrlc = { version = "3.2.3", features = ["termination"] }
 image = "0.24.4"
 rayon = "1.5.3"

--- a/asciic/src/cli.rs
+++ b/asciic/src/cli.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+use clap::{value_parser, Arg, Command};
+
+use crate::primitives::{OutputSize, PaintStyle};
+
+#[inline]
+pub fn cli() -> Command<'static> {
+    Command::new("asciic")
+        .version("0.3.0")
+        .about("An asciinema compiler")
+        .author("by S0ra")
+        .args(args())
+}
+
+#[inline]
+fn args() -> [Arg<'static>; 10] {
+    [
+        Arg::new("video")
+            .required_unless_present("image")
+            .conflicts_with("image")
+            .index(1)
+            .help("Input video to transform in asciinema")
+            .takes_value(true),
+        Arg::new("output")
+            .value_parser(value_parser!(PathBuf))
+            .default_value("output")
+            .conflicts_with("image")
+            .help("Output file name")
+            .index(2),
+        Arg::new("frame-size")
+            .short('s')
+            .default_value("216x56")
+            .long("size")
+            .takes_value(true)
+            .required(false)
+            .help("The ratio that each frame should be resized")
+            .value_parser(value_parser!(OutputSize)),
+        Arg::new("image")
+            .short('i')
+            .long("image")
+            .takes_value(true)
+            .help("Compiles a single image"),
+        Arg::new("colorize").short('c').help("Colorize output"),
+        Arg::new("no-compression")
+            .short('n')
+            .long("skip-compression")
+            .help("Disables compression on colored outputs")
+            .requires("colorize"),
+        Arg::new("compression-threshold")
+            .short('t')
+            .long("threshold")
+            .default_value("10")
+            .requires("colorize")
+            .takes_value(true)
+            .value_parser(value_parser!(u8))
+            .help("Manually sets the compression threshold"),
+        Arg::new("ffmpeg-flags")
+            .index(3)
+            .multiple_occurrences(true)
+            .allow_hyphen_values(true)
+            .takes_value(true)
+            .conflicts_with("image")
+            .multiple_values(true)
+            .value_parser(value_parser!(String))
+            .help("Pass extra flags to ffmpeg")
+            .last(true),
+        Arg::new("no-audio")
+            .long("no-audio")
+            .help("Skips audio generation")
+            .conflicts_with("image"),
+        Arg::new("style")
+            .takes_value(true)
+            .long("style")
+            .help("Sets a style to follow when generating frames")
+            .default_value("bg-only")
+            .value_parser(value_parser!(PaintStyle)),
+    ]
+}

--- a/asciic/src/primitives.rs
+++ b/asciic/src/primitives.rs
@@ -1,0 +1,75 @@
+use clap::{
+    builder::{TypedValueParser, ValueParserFactory},
+    ErrorKind, ValueEnum,
+};
+
+#[derive(Clone, Copy)]
+pub struct Options {
+    pub compression_threshold: u8,
+    pub redimension: OutputSize,
+    pub skip_compression: bool,
+    pub style: PaintStyle,
+    pub colorize: bool,
+    pub skip_audio: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum PaintStyle {
+    FgPaint,
+    BgPaint,
+    BgOnly,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OutputSize(pub u32, pub u32);
+impl ValueParserFactory for OutputSize {
+    type Parser = OutputSizeParser;
+
+    fn value_parser() -> Self::Parser {
+        OutputSizeParser
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OutputSizeParser;
+impl TypedValueParser for OutputSizeParser {
+    type Value = OutputSize;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        _: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let value = value
+            .to_str()
+            .ok_or_else(|| {
+                cmd.clone()
+                    .error(ErrorKind::InvalidUtf8, "Not UTF8, try 216x56.")
+            })?
+            .to_ascii_lowercase();
+
+        let vals = value.split('x').collect::<Vec<_>>();
+        if vals.len() != 2 {
+            return Err(cmd
+                .clone()
+                .error(ErrorKind::InvalidValue, "Wrong pattern, try 216x56."));
+        }
+        let output_size = OutputSize(
+            vals.first()
+                .unwrap()
+                .parse::<u32>()
+                .map_err(|e| cmd.clone().error(ErrorKind::InvalidValue, e.to_string()))?,
+            vals.last()
+                .unwrap()
+                .parse::<u32>()
+                .map_err(|e| cmd.clone().error(ErrorKind::InvalidValue, e.to_string()))?,
+        );
+
+        if output_size.0 > 400 || output_size.1 > 200 {
+            println!("WARN: Usually going too high on frame size makes stuff a bit wonky.");
+        }
+
+        Ok(output_size)
+    }
+}

--- a/asciic/src/util.rs
+++ b/asciic/src/util.rs
@@ -1,27 +1,13 @@
 use std::{
     fs::{remove_dir_all, File},
     io,
-    path::{Path, PathBuf},
+    path::Path,
     process::{abort, Command, Stdio},
     thread::sleep,
     time::Duration,
 };
 
-use clap::{
-    builder::{TypedValueParser, ValueParserFactory},
-    value_parser, Arg, Command as Clap, ErrorKind,
-};
 use tar::{Builder, Header};
-
-#[derive(Clone, Copy)]
-pub struct Options {
-    pub compression_threshold: u8,
-    pub redimension: OutputSize,
-    pub skip_compression: bool,
-    pub paint_fg: bool,
-    pub colorize: bool,
-    pub skip_audio: bool,
-}
 
 pub fn clean_abort(tmp_path: &Path) -> ! {
     sleep(Duration::from_secs(2));
@@ -78,124 +64,4 @@ pub fn ffmpeg(args: &[&str], extra_flags: &[&String]) -> Result<(), Box<dyn std:
 #[inline]
 pub fn max_sub(a: u8, b: u8) -> u8 {
     a.max(b) - a.min(b)
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct OutputSize(pub u32, pub u32);
-impl ValueParserFactory for OutputSize {
-    type Parser = OutputSizeParser;
-
-    fn value_parser() -> Self::Parser {
-        OutputSizeParser
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct OutputSizeParser;
-impl TypedValueParser for OutputSizeParser {
-    type Value = OutputSize;
-
-    fn parse_ref(
-        &self,
-        cmd: &clap::Command,
-        _: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        let value = value
-            .to_str()
-            .ok_or_else(|| {
-                cmd.clone()
-                    .error(ErrorKind::InvalidUtf8, "Not UTF8, try 216x56.")
-            })?
-            .to_ascii_lowercase();
-
-        let vals = value.split('x').collect::<Vec<_>>();
-        if vals.len() != 2 {
-            return Err(cmd
-                .clone()
-                .error(ErrorKind::InvalidValue, "Wrong pattern, try 216x56."));
-        }
-        let output_size = OutputSize(
-            vals.first()
-                .unwrap()
-                .parse::<u32>()
-                .map_err(|e| cmd.clone().error(ErrorKind::InvalidValue, e.to_string()))?,
-            vals.last()
-                .unwrap()
-                .parse::<u32>()
-                .map_err(|e| cmd.clone().error(ErrorKind::InvalidValue, e.to_string()))?,
-        );
-
-        if output_size.0 > 400 || output_size.1 > 200 {
-            println!("WARN: Usually going too high on frame size makes stuff a bit wonky.");
-        }
-
-        Ok(output_size)
-    }
-}
-
-pub fn cli() -> Clap<'static> {
-    Clap::new("asciic")
-        .version("0.3.0")
-        .about("An asciinema compiler")
-        .author("by S0ra")
-        .args([
-            Arg::new("video")
-                .required_unless_present("image")
-                .conflicts_with("image")
-                .index(1)
-                .help("Input video to transform in asciinema")
-                .takes_value(true),
-            Arg::new("output")
-                .value_parser(value_parser!(PathBuf))
-                .default_value("output")
-                .conflicts_with("image")
-                .help("Output file name")
-                .index(2),
-            Arg::new("frame-size")
-                .short('s')
-                .default_value("216x56")
-                .long("size")
-                .takes_value(true)
-                .required(false)
-                .help("The ratio that each frame should be resized")
-                .value_parser(value_parser!(OutputSize)),
-            Arg::new("image")
-                .short('i')
-                .long("image")
-                .takes_value(true)
-                .help("Compiles a single image"),
-            Arg::new("colorize").short('c').help("Colorize output"),
-            Arg::new("no-compression")
-                .short('n')
-                .long("skip-compression")
-                .help("Disables compression on colored outputs")
-                .requires("colorize"),
-            Arg::new("compression-threshold")
-                .short('t')
-                .long("threshold")
-                .default_value("10")
-                .requires("colorize")
-                .takes_value(true)
-                .value_parser(value_parser!(u8))
-                .help("Manually sets the compression threshold"),
-            Arg::new("paint-fg")
-                .long("paint-fg")
-                .requires("colorize")
-                .help("Paints the foreground instead of background"),
-            Arg::new("ffmpeg-flags")
-                .index(3)
-                .multiple_occurrences(true)
-                .allow_hyphen_values(true)
-                .takes_value(true)
-                .conflicts_with("image")
-                .multiple_values(true)
-                .value_parser(value_parser!(String))
-                .help("Pass extra flags to ffmpeg")
-                .last(true),
-            Arg::new("no-audio")
-                .long("no-audio")
-                .help("skips audio generation")
-                .conflicts_with("image"),
-        ])
 }


### PR DESCRIPTION
Basically adds a `--style` arg, that accepts some options:
- **bg-paint**: The old default, paints background and includes chars other than space;
- **fg-paint**: Paints foreground, includes chars for obvious reasons;
- **bg-only**: Paints background only, new default that also increases performance when printing frames to the terminal.