### PR TITLE
Fix style on colorless builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "asciic"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "ctrlc",

--- a/asciic/Cargo.toml
+++ b/asciic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciic"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/asciic/src/cli.rs
+++ b/asciic/src/cli.rs
@@ -70,10 +70,13 @@ fn args() -> [Arg<'static>; 10] {
             .help("Skips audio generation")
             .conflicts_with("image"),
         Arg::new("style")
+            .requires("colorize")
             .takes_value(true)
             .long("style")
-            .help("Sets a style to follow when generating frames")
-            .default_value("bg-only")
+            .help("Sets a style to follow when generating frames [default: bg-only]")
+            .default_value_if("colorize", None, Some("bg-only"))
+            .default_value("bg-paint")
+            .hide_default_value(true)
             .value_parser(value_parser!(PaintStyle)),
     ]
 }


### PR DESCRIPTION
This solves a bug reported by @yxqsnz that was introduced [here](https://github.com/S0raWasTaken/bad_apple/commit/9cfad0ba4499cac9a59d3648b3735eff5a0e293f#diff-d8daea476a873434d5c5a40ec2c49edf27284924138eabc4d942da82855b4873R76).

I also added an `Arg::requires` on the style arg because I forgot.