### PR TITLE
Fix non-deterministic frame ordering on some systems

### DIFF
--- a/asciic/src/primitives.rs
+++ b/asciic/src/primitives.rs
@@ -163,12 +163,11 @@ impl AsciiCompiler {
 
                 // Early fail: filename must be a number
                 {
-                    let stem = entry
+                    let _: u64 = entry
                         .file_stem()
                         .and_then(|s| s.to_str())
+                        .and_then(|stem| stem.parse().ok())
                         .ok_or(FILE_STEM_NAN)?;
-
-                    let _: u64 = stem.parse()?;
                 }
 
                 print!(


### PR DESCRIPTION
Fixes race condition where frames could be mapped out of order on some systems due to non-deterministic parallel iteration behavior.

Changes:
- Add early validation that file stems are valid numbers
- Explicitly sort frames by numeric value after parallel processing
- Add descriptive error message for invalid file stems

This ensures consistent frame ordering regardless of CPU/system behavior.

Fixes #20 